### PR TITLE
Author url is now linked to author profile

### DIFF
--- a/discordbot.py
+++ b/discordbot.py
@@ -54,7 +54,7 @@ def embed_from_post(post):
 	)
 	embed.set_author(
 		name=post.author.name,
-		url=post.url,
+		url=post.author.url,
 		icon_url=post.author.avatar
 	)
 	embed.set_footer(text=board_name)


### PR DESCRIPTION
Replaces the author url with the repl profile instead of the post.